### PR TITLE
add: フラッシュカード機能追加

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { type User } from "firebase/auth";
 import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 import { observeAuthState } from "@/lib/auth";
 import AppPage from "@/routes/AppPage";
+import FlashCardsPage from "@/routes/FlashCardsPage";
 import SignInPage from "@/routes/SignInPage";
 
 function App() {
@@ -38,6 +39,16 @@ function App() {
           path="/app"
           element={
             user ? <AppPage userName={user.displayName} /> : <Navigate to="/signin" replace />
+          }
+        />
+        <Route
+          path="/flash_cards"
+          element={
+            user ? (
+              <FlashCardsPage userName={user.displayName} />
+            ) : (
+              <Navigate to="/signin" replace />
+            )
           }
         />
         <Route path="*" element={<Navigate to={user ? "/app" : "/signin"} replace />} />

--- a/apps/frontend/src/components/AppHeader.tsx
+++ b/apps/frontend/src/components/AppHeader.tsx
@@ -1,0 +1,82 @@
+import { BookOpenCheck, LogOut, Mic2 } from "lucide-react";
+import { Link, useLocation } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { logout } from "@/lib/auth";
+import { cn } from "@/lib/utils";
+
+type AppHeaderProps = {
+  userName: string | null;
+  subtitle: string;
+};
+
+const navItems = [
+  { to: "/app", label: "Practice", icon: Mic2 },
+  { to: "/flash_cards", label: "Cards", icon: BookOpenCheck },
+];
+
+function AppHeader({ userName, subtitle }: AppHeaderProps) {
+  const location = useLocation();
+
+  return (
+    <header className="space-y-4 text-left">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center justify-start gap-5">
+          <img
+            src="/app_icon.png"
+            alt="re-say icon"
+            className="h-16 w-16 rounded-2xl shadow-md ring-1 ring-black/10"
+          />
+          <div className="space-y-1">
+            <span className="text-balance text-4xl font-black leading-tight tracking-tight text-slate-900 dark:text-white">
+              re-say!
+            </span>
+            <p className="text-sm font-light text-slate-600 dark:text-slate-300">{subtitle}</p>
+          </div>
+        </div>
+
+        <Button
+          type="button"
+          variant="outline"
+          onClick={logout}
+          className="h-11 shrink-0 border-slate-300/80 bg-white/85 px-4 text-sm"
+        >
+          <LogOut className="size-4" />
+          Sign out
+        </Button>
+      </div>
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <nav className="flex flex-wrap gap-2">
+          {navItems.map((item) => {
+            const isActive = location.pathname === item.to;
+            const Icon = item.icon;
+
+            return (
+              <Link
+                key={item.to}
+                to={item.to}
+                className={cn(
+                  "inline-flex h-10 items-center justify-center gap-2 rounded-md border px-4 text-sm font-medium transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none",
+                  isActive
+                    ? "border-orange-500 bg-orange-500 text-white shadow-sm hover:bg-orange-500/90"
+                    : "border-slate-300/80 bg-white/85 text-slate-700 shadow-xs hover:bg-cyan-50 hover:text-slate-950",
+                )}
+              >
+                <Icon className="size-4" />
+                {item.label}
+              </Link>
+            );
+          })}
+        </nav>
+
+        {userName && (
+          <p className="text-sm font-medium text-slate-600 dark:text-slate-300">
+            Signed in as {userName}
+          </p>
+        )}
+      </div>
+    </header>
+  );
+}
+
+export default AppHeader;

--- a/apps/frontend/src/components/flash-cards/FlashCards.tsx
+++ b/apps/frontend/src/components/flash-cards/FlashCards.tsx
@@ -1,0 +1,349 @@
+import { ChevronLeft, ChevronRight, LoaderCircle, RotateCcw, Volume2, VolumeX } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState, type PointerEvent } from "react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { synthesizeExampleSpeech } from "@/services/assessmentApi";
+import { ankiPackages } from "./content";
+
+const SWIPE_THRESHOLD_PX = 64;
+const TAP_MOVEMENT_THRESHOLD_PX = 10;
+
+type PointerStart = {
+  x: number;
+  y: number;
+};
+
+function FlashCards() {
+  const [selectedPackageIndex, setSelectedPackageIndex] = useState(0);
+  const packageEntry = ankiPackages[selectedPackageIndex] ?? ankiPackages[0];
+  const phrases = useMemo(() => packageEntry?.phrases ?? [], [packageEntry?.phrases]);
+  const [cardIndex, setCardIndex] = useState(0);
+  const [isFlipped, setIsFlipped] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isSynthesizingSpeech, setIsSynthesizingSpeech] = useState(false);
+  const [isPlayingSpeech, setIsPlayingSpeech] = useState(false);
+  const pointerStartRef = useRef<PointerStart | null>(null);
+  const speechAudioRef = useRef<HTMLAudioElement | null>(null);
+  const speechRequestIdRef = useRef(0);
+
+  const currentPhrase = phrases[cardIndex];
+  const totalCards = phrases.length;
+  const primaryText = isFlipped ? currentPhrase?.answer : currentPhrase?.question;
+  const translationText = isFlipped ? currentPhrase?.answerJa : currentPhrase?.questionJa;
+
+  const stopSpeech = useCallback((): void => {
+    const audio = speechAudioRef.current;
+    if (!audio) {
+      return;
+    }
+
+    audio.pause();
+    audio.onended = null;
+    audio.onerror = null;
+
+    const sourceUrl = audio.src;
+    speechAudioRef.current = null;
+
+    if (sourceUrl.startsWith("blob:")) {
+      URL.revokeObjectURL(sourceUrl);
+    }
+
+    setIsPlayingSpeech(false);
+  }, []);
+
+  const cancelSpeech = useCallback((): void => {
+    speechRequestIdRef.current += 1;
+    stopSpeech();
+    setIsSynthesizingSpeech(false);
+  }, [stopSpeech]);
+
+  const moveCard = useCallback(
+    (direction: "prev" | "next"): void => {
+      if (totalCards === 0) {
+        return;
+      }
+
+      cancelSpeech();
+      setError(null);
+      setIsFlipped(false);
+      setCardIndex((current) => {
+        if (direction === "prev") {
+          return current === 0 ? totalCards - 1 : current - 1;
+        }
+
+        return current === totalCards - 1 ? 0 : current + 1;
+      });
+    },
+    [cancelSpeech, totalCards],
+  );
+
+  const selectPackage = (index: number): void => {
+    if (index === selectedPackageIndex) {
+      return;
+    }
+
+    cancelSpeech();
+    setSelectedPackageIndex(index);
+    setCardIndex(0);
+    setIsFlipped(false);
+    setError(null);
+  };
+
+  const playSpeech = async (): Promise<void> => {
+    if (isPlayingSpeech) {
+      stopSpeech();
+      return;
+    }
+
+    if (!currentPhrase) {
+      setError("No flash card is available.");
+      return;
+    }
+
+    setError(null);
+    setIsSynthesizingSpeech(true);
+
+    const requestId = speechRequestIdRef.current + 1;
+    speechRequestIdRef.current = requestId;
+
+    try {
+      const audioBlob = await synthesizeExampleSpeech(currentPhrase.answer);
+
+      if (speechRequestIdRef.current !== requestId) {
+        return;
+      }
+
+      const audioUrl = URL.createObjectURL(audioBlob);
+
+      stopSpeech();
+
+      const audio = new Audio();
+      audio.preload = "auto";
+      audio.setAttribute("playsinline", "true");
+      audio.src = audioUrl;
+      speechAudioRef.current = audio;
+
+      audio.onended = () => {
+        if (audioUrl.startsWith("blob:")) {
+          URL.revokeObjectURL(audioUrl);
+        }
+        if (speechAudioRef.current === audio) {
+          speechAudioRef.current = null;
+        }
+        setIsPlayingSpeech(false);
+      };
+
+      audio.onerror = () => {
+        if (audioUrl.startsWith("blob:")) {
+          URL.revokeObjectURL(audioUrl);
+        }
+        if (speechAudioRef.current === audio) {
+          speechAudioRef.current = null;
+        }
+        setIsPlayingSpeech(false);
+        setError("Failed to play answer speech.");
+      };
+
+      audio.load();
+      await audio.play();
+      setIsPlayingSpeech(true);
+    } catch (caught) {
+      if (speechRequestIdRef.current !== requestId) {
+        return;
+      }
+
+      stopSpeech();
+      setError(caught instanceof Error ? caught.message : "Failed to synthesize answer speech.");
+    } finally {
+      if (speechRequestIdRef.current === requestId) {
+        setIsSynthesizingSpeech(false);
+      }
+    }
+  };
+
+  const handlePointerDown = (event: PointerEvent<HTMLButtonElement>): void => {
+    pointerStartRef.current = { x: event.clientX, y: event.clientY };
+    event.currentTarget.setPointerCapture(event.pointerId);
+  };
+
+  const handlePointerUp = (event: PointerEvent<HTMLButtonElement>): void => {
+    const pointerStart = pointerStartRef.current;
+    pointerStartRef.current = null;
+
+    if (!pointerStart) {
+      return;
+    }
+
+    const deltaX = event.clientX - pointerStart.x;
+    const deltaY = event.clientY - pointerStart.y;
+    const absX = Math.abs(deltaX);
+    const absY = Math.abs(deltaY);
+
+    if (absX >= SWIPE_THRESHOLD_PX && absX > absY * 1.25) {
+      moveCard(deltaX < 0 ? "next" : "prev");
+      return;
+    }
+
+    if (absX <= TAP_MOVEMENT_THRESHOLD_PX && absY <= TAP_MOVEMENT_THRESHOLD_PX) {
+      setIsFlipped((current) => !current);
+    }
+  };
+
+  const handlePointerCancel = (): void => {
+    pointerStartRef.current = null;
+  };
+
+  useEffect(() => () => cancelSpeech(), [cancelSpeech]);
+
+  if (!packageEntry || !currentPhrase) {
+    return (
+      <Alert>
+        <RotateCcw className="size-4" />
+        <AlertTitle>No flash cards</AlertTitle>
+        <AlertDescription>
+          Add at least one valid anki package with question and answer pairs.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="grid gap-4 md:grid-cols-[minmax(0,26rem)_1fr] md:items-end">
+        <label className="space-y-1.5">
+          <span className="text-xs font-semibold tracking-[0.18em] text-slate-500 uppercase">
+            Topic
+          </span>
+          <select
+            value={selectedPackageIndex}
+            onChange={(event) => selectPackage(Number(event.target.value))}
+            className="w-full rounded-xl border border-slate-300/80 bg-white/90 px-3 py-2.5 text-sm text-slate-900 shadow-sm outline-none focus:border-orange-400 focus:ring-2 focus:ring-orange-200"
+          >
+            {ankiPackages.map((entry, index) => (
+              <option key={entry.topic} value={index}>
+                {entry.topic}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <div className="flex flex-col gap-1 md:items-end">
+          <p className="text-xs font-semibold tracking-[0.2em] text-slate-500 uppercase">
+            Current card
+          </p>
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+            <h1 className="text-2xl font-bold tracking-tight text-slate-950">
+              {packageEntry.topic}
+            </h1>
+            <p className="text-sm font-semibold text-slate-600">
+              {cardIndex + 1} / {totalCards}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <button
+        type="button"
+        onPointerDown={handlePointerDown}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerCancel}
+        className="group block w-full touch-pan-y rounded-xl text-left outline-none focus-visible:ring-[3px] focus-visible:ring-orange-300"
+        aria-label={isFlipped ? "Show question" : "Show answer"}
+      >
+        <Card className="min-h-[22rem] overflow-hidden border-slate-900/10 bg-white/85 py-0 shadow-[0_24px_80px_-36px_rgba(15,23,42,0.55)] transition-transform duration-200 group-active:scale-[0.99] dark:border-white/10 dark:bg-slate-900/70">
+          <CardContent className="flex min-h-[22rem] flex-col justify-between gap-8 p-6 sm:p-8">
+            <div className="flex items-center justify-between gap-3">
+              <span
+                className={cn(
+                  "rounded-full px-3 py-1 text-xs font-bold tracking-[0.14em] uppercase",
+                  isFlipped ? "bg-cyan-100 text-cyan-800" : "bg-orange-100 text-orange-800",
+                )}
+              >
+                {isFlipped ? "Answer" : "Question"}
+              </span>
+              <span className="text-xs font-medium text-slate-400">
+                {isFlipped ? "Tap to return" : "Tap to reveal"}
+              </span>
+            </div>
+
+            <div className="flex flex-1 items-center">
+              <div className="w-full space-y-5 text-center">
+                <p
+                  className={cn(
+                    "text-balance font-bold leading-tight tracking-normal text-slate-950",
+                    isFlipped ? "text-3xl sm:text-4xl" : "text-4xl sm:text-5xl",
+                  )}
+                >
+                  {primaryText}
+                </p>
+                <p className="mx-auto max-w-3xl text-balance text-base font-normal leading-relaxed text-slate-600 sm:text-lg">
+                  {translationText}
+                </p>
+              </div>
+            </div>
+
+            <div className="text-center text-xs font-medium text-slate-500">
+              Swipe left for next. Swipe right for previous.
+            </div>
+          </CardContent>
+        </Card>
+      </button>
+
+      <div className="grid grid-cols-3 gap-2 sm:mx-auto sm:max-w-lg sm:gap-3">
+        <Button
+          type="button"
+          onClick={() => moveCard("prev")}
+          size="lg"
+          variant="outline"
+          className="h-12 rounded-full border-slate-300/80 bg-white/90 px-3 text-sm shadow-sm"
+        >
+          <ChevronLeft className="size-4" />
+          Prev
+        </Button>
+        <Button
+          type="button"
+          onClick={playSpeech}
+          disabled={isSynthesizingSpeech}
+          size="lg"
+          className={cn(
+            "h-12 rounded-full px-3 text-sm text-white shadow-lg",
+            isPlayingSpeech
+              ? "bg-slate-700 shadow-slate-500/35 hover:bg-slate-600"
+              : "bg-sky-600 shadow-sky-500/35 hover:bg-sky-500",
+          )}
+        >
+          {isSynthesizingSpeech ? (
+            <LoaderCircle className="size-4 animate-spin" />
+          ) : isPlayingSpeech ? (
+            <VolumeX className="size-4" />
+          ) : (
+            <Volume2 className="size-4" />
+          )}
+          Speak
+        </Button>
+        <Button
+          type="button"
+          onClick={() => moveCard("next")}
+          size="lg"
+          variant="outline"
+          className="h-12 rounded-full border-slate-300/80 bg-white/90 px-3 text-sm shadow-sm"
+        >
+          Next
+          <ChevronRight className="size-4" />
+        </Button>
+      </div>
+
+      {error && (
+        <Alert variant="destructive">
+          <VolumeX className="size-4" />
+          <AlertTitle>Speech failed</AlertTitle>
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+    </div>
+  );
+}
+
+export default FlashCards;

--- a/apps/frontend/src/components/flash-cards/content.ts
+++ b/apps/frontend/src/components/flash-cards/content.ts
@@ -1,0 +1,18 @@
+import contents from "../../data/anki-contents.json";
+import type { AnkiContents, AnkiPackage, AnkiPhrase } from "./types";
+
+const ankiContents = contents as AnkiContents;
+
+const isValidPhrase = (phrase: AnkiPhrase): boolean =>
+  phrase.question.trim().length > 0 &&
+  phrase.questionJa.trim().length > 0 &&
+  phrase.answer.trim().length > 0 &&
+  phrase.answerJa.trim().length > 0;
+
+export const ankiPackages = ankiContents.packages
+  .filter((entry): entry is AnkiPackage => entry.mode === "anki")
+  .map((entry) => ({
+    ...entry,
+    phrases: entry.phrases.filter(isValidPhrase),
+  }))
+  .filter((entry) => entry.topic.trim().length > 0 && entry.phrases.length > 0);

--- a/apps/frontend/src/components/flash-cards/types.ts
+++ b/apps/frontend/src/components/flash-cards/types.ts
@@ -1,0 +1,16 @@
+export type AnkiPhrase = {
+  question: string;
+  questionJa: string;
+  answer: string;
+  answerJa: string;
+};
+
+export type AnkiPackage = {
+  topic: string;
+  mode: "anki" | string;
+  phrases: AnkiPhrase[];
+};
+
+export type AnkiContents = {
+  packages: AnkiPackage[];
+};

--- a/apps/frontend/src/data/anki-contents.json
+++ b/apps/frontend/src/data/anki-contents.json
@@ -1,0 +1,598 @@
+{
+  "packages": [
+    {
+      "topic": "Repair and clarification",
+      "mode": "anki",
+      "phrases": [
+        {
+          "question": "Sorry, could you say that again?",
+          "questionJa": "すみません、もう一度言ってもらえますか？",
+          "answer": "Sure. I said the train leaves at 3:20.",
+          "answerJa": "もちろんです。電車は3時20分に出ると言いました。"
+        },
+        {
+          "question": "Could you say that more slowly?",
+          "questionJa": "もう少しゆっくり言ってもらえますか？",
+          "answer": "Of course. I’ll speak more slowly.",
+          "answerJa": "もちろんです。もう少しゆっくり話します。"
+        },
+        {
+          "question": "Could you repeat the last part?",
+          "questionJa": "最後の部分だけもう一度お願いできますか？",
+          "answer": "Sure. The gate number is 24.",
+          "answerJa": "もちろんです。ゲート番号は24です。"
+        },
+        {
+          "question": "Sorry, I didn’t catch that.",
+          "questionJa": "すみません、聞き取れませんでした。",
+          "answer": "No problem. I’ll say it again.",
+          "answerJa": "大丈夫です。もう一度言います。"
+        },
+        {
+          "question": "Do you mean I should pay here?",
+          "questionJa": "つまり、ここで支払えばいいということですか？",
+          "answer": "Yes, please pay at this counter.",
+          "answerJa": "はい、このカウンターで支払ってください。"
+        },
+        {
+          "question": "So I need to go to gate 24, right?",
+          "questionJa": "つまり、24番ゲートに行けばいいんですよね？",
+          "answer": "Yes, that’s right. Gate 24 is this way.",
+          "answerJa": "はい、その通りです。24番ゲートはこちらです。"
+        },
+        {
+          "question": "What does that mean?",
+          "questionJa": "それはどういう意味ですか？",
+          "answer": "It means you need to wait here.",
+          "answerJa": "ここで待つ必要があるという意味です。"
+        },
+        {
+          "question": "What does this word mean?",
+          "questionJa": "この単語はどういう意味ですか？",
+          "answer": "It means the item is not available right now.",
+          "answerJa": "その商品は今は利用できないという意味です。"
+        },
+        {
+          "question": "Can you decide now?",
+          "questionJa": "今決められますか？",
+          "answer": "Let me think for a second.",
+          "answerJa": "少し考えさせてください。"
+        },
+        {
+          "question": "Could you say that one more time?",
+          "questionJa": "もう一度言ってもらえますか？",
+          "answer": "Sorry, let me try again.",
+          "answerJa": "すみません、もう一度言い直します。"
+        }
+      ]
+    },
+    {
+      "topic": "Airport and immigration",
+      "mode": "anki",
+      "phrases": [
+        {
+          "question": "What is the purpose of your visit?",
+          "questionJa": "渡航目的は何ですか？",
+          "answer": "I’m here for sightseeing.",
+          "answerJa": "観光で来ました。"
+        },
+        {
+          "question": "How long will you stay?",
+          "questionJa": "どれくらい滞在しますか？",
+          "answer": "I’ll stay for seven days.",
+          "answerJa": "7日間滞在します。"
+        },
+        {
+          "question": "Where are you staying?",
+          "questionJa": "どこに滞在しますか？",
+          "answer": "I’m staying at this hotel.",
+          "answerJa": "このホテルに泊まります。"
+        },
+        {
+          "question": "Do you have a return ticket?",
+          "questionJa": "帰りの航空券は持っていますか？",
+          "answer": "Yes, I have a return ticket.",
+          "answerJa": "はい、帰りの航空券を持っています。"
+        },
+        {
+          "question": "Are you here for work?",
+          "questionJa": "仕事で来ましたか？",
+          "answer": "No, I’m here on vacation, not for work.",
+          "answerJa": "いいえ、仕事ではなく休暇です。"
+        },
+        {
+          "question": "Is this your first time here?",
+          "questionJa": "ここに来るのは初めてですか？",
+          "answer": "Yes, this is my first time in this country.",
+          "answerJa": "はい、この国に来るのは初めてです。"
+        },
+        {
+          "question": "Do you have anything to declare?",
+          "questionJa": "申告するものはありますか？",
+          "answer": "I have nothing to declare.",
+          "answerJa": "申告するものはありません。"
+        },
+        {
+          "question": "Could you open your bag, please?",
+          "questionJa": "バッグを開けてもらえますか？",
+          "answer": "Sure. This is all my luggage.",
+          "answerJa": "はい。荷物はこれだけです。"
+        },
+        {
+          "question": "Where should I go next after immigration?",
+          "questionJa": "入国審査の後、次にどこへ行けばよいですか？",
+          "answer": "Please go to baggage claim on the right.",
+          "answerJa": "右側の手荷物受取所へ行ってください。"
+        },
+        {
+          "question": "Are you meeting anyone during your trip?",
+          "questionJa": "旅行中に誰かに会う予定はありますか？",
+          "answer": "Yes, I’m here to meet a friend.",
+          "answerJa": "はい、友人に会いに来ました。"
+        }
+      ]
+    },
+    {
+      "topic": "Hotel",
+      "mode": "anki",
+      "phrases": [
+        {
+          "question": "Hello. How can I help you?",
+          "questionJa": "こんにちは。ご用件をお伺いします。",
+          "answer": "I’d like to check in.",
+          "answerJa": "チェックインしたいです。"
+        },
+        {
+          "question": "Do you have a reservation?",
+          "questionJa": "予約はありますか？",
+          "answer": "Yes, I have a reservation.",
+          "answerJa": "はい、予約しています。"
+        },
+        {
+          "question": "May I have your name?",
+          "questionJa": "お名前を教えていただけますか？",
+          "answer": "My name is Taro Yamada.",
+          "answerJa": "名前は山田太郎です。"
+        },
+        {
+          "question": "May I see your passport?",
+          "questionJa": "パスポートを見せていただけますか？",
+          "answer": "Sure. Should I show my passport here?",
+          "answerJa": "はい。ここでパスポートを見せればいいですか？"
+        },
+        {
+          "question": "Is breakfast included?",
+          "questionJa": "朝食は含まれていますか？",
+          "answer": "Yes, breakfast is included from 7 to 10.",
+          "answerJa": "はい、朝食は7時から10時まで含まれています。"
+        },
+        {
+          "question": "Could you tell me the Wi-Fi password?",
+          "questionJa": "Wi-Fiのパスワードを教えてもらえますか？",
+          "answer": "Sure. It’s written on this card.",
+          "answerJa": "もちろんです。このカードに書いてあります。"
+        },
+        {
+          "question": "What time is check-out?",
+          "questionJa": "チェックアウトは何時ですか？",
+          "answer": "Check-out is at 11 a.m.",
+          "answerJa": "チェックアウトは午前11時です。"
+        },
+        {
+          "question": "Could you keep my luggage?",
+          "questionJa": "荷物を預かってもらえますか？",
+          "answer": "Of course. We can keep it at the front desk.",
+          "answerJa": "もちろんです。フロントでお預かりできます。"
+        },
+        {
+          "question": "What seems to be the problem with your room?",
+          "questionJa": "お部屋にどのような問題がありますか？",
+          "answer": "The air conditioner in my room doesn’t work.",
+          "answerJa": "部屋のエアコンが動きません。"
+        },
+        {
+          "question": "Is it possible to change rooms?",
+          "questionJa": "部屋を変えてもらうことはできますか？",
+          "answer": "Let me check. We may have another room available.",
+          "answerJa": "確認します。別の部屋が空いているかもしれません。"
+        }
+      ]
+    },
+    {
+      "topic": "Restaurant",
+      "mode": "anki",
+      "phrases": [
+        {
+          "question": "How many people?",
+          "questionJa": "何名ですか？",
+          "answer": "Table for one, please.",
+          "answerJa": "1人です。"
+        },
+        {
+          "question": "How many people?",
+          "questionJa": "何名ですか？",
+          "answer": "Table for two, please.",
+          "answerJa": "2人です。"
+        },
+        {
+          "question": "Could I see the menu?",
+          "questionJa": "メニューを見てもいいですか？",
+          "answer": "Of course. Here you go.",
+          "answerJa": "もちろんです。どうぞ。"
+        },
+        {
+          "question": "Do you have any recommendations?",
+          "questionJa": "おすすめはありますか？",
+          "answer": "Yes, the grilled fish is very popular.",
+          "answerJa": "はい、焼き魚がとても人気です。"
+        },
+        {
+          "question": "What is this?",
+          "questionJa": "これは何ですか？",
+          "answer": "It’s a local soup with vegetables and chicken.",
+          "answerJa": "野菜と鶏肉が入った地元のスープです。"
+        },
+        {
+          "question": "Is it spicy?",
+          "questionJa": "辛いですか？",
+          "answer": "It’s a little spicy, but we can make it mild.",
+          "answerJa": "少し辛いですが、辛さ控えめにできます。"
+        },
+        {
+          "question": "Could you make it not spicy?",
+          "questionJa": "辛くしないでください。",
+          "answer": "Sure. We’ll make it not spicy.",
+          "answerJa": "承知しました。辛くしないようにします。"
+        },
+        {
+          "question": "Are you ready to order?",
+          "questionJa": "ご注文はお決まりですか？",
+          "answer": "I’ll have this, please.",
+          "answerJa": "これをお願いします。"
+        },
+        {
+          "question": "Could I have some water?",
+          "questionJa": "水をもらえますか？",
+          "answer": "Sure. I’ll bring it right away.",
+          "answerJa": "もちろんです。すぐにお持ちします。"
+        },
+        {
+          "question": "Could I have the bill, please?",
+          "questionJa": "お会計をお願いします。",
+          "answer": "Of course. I’ll bring it to your table.",
+          "answerJa": "承知しました。テーブルまでお持ちします。"
+        }
+      ]
+    },
+    {
+      "topic": "Shopping",
+      "mode": "anki",
+      "phrases": [
+        {
+          "question": "How much is this?",
+          "questionJa": "これはいくらですか？",
+          "answer": "It’s twenty dollars.",
+          "answerJa": "20ドルです。"
+        },
+        {
+          "question": "Can I help you find anything?",
+          "questionJa": "何かお探しですか？",
+          "answer": "I’m just looking, thank you.",
+          "answerJa": "見ているだけです。ありがとうございます。"
+        },
+        {
+          "question": "Do you have this in a smaller size?",
+          "questionJa": "これの小さいサイズはありますか？",
+          "answer": "Yes, we have a small size in the back.",
+          "answerJa": "はい、奥に小さいサイズがあります。"
+        },
+        {
+          "question": "Do you have this in another color?",
+          "questionJa": "これの別の色はありますか？",
+          "answer": "Yes, we also have it in black and blue.",
+          "answerJa": "はい、黒と青もあります。"
+        },
+        {
+          "question": "Can I try this on?",
+          "questionJa": "試着してもいいですか？",
+          "answer": "Sure. The fitting room is over there.",
+          "answerJa": "もちろんです。試着室はあちらです。"
+        },
+        {
+          "question": "Can I pay by card?",
+          "questionJa": "カードで払えますか？",
+          "answer": "Yes, we accept credit cards.",
+          "answerJa": "はい、クレジットカードをご利用いただけます。"
+        },
+        {
+          "question": "How would you like to pay?",
+          "questionJa": "お支払い方法はどうされますか？",
+          "answer": "I’ll pay in cash.",
+          "answerJa": "現金で払います。"
+        },
+        {
+          "question": "Could I have a bag?",
+          "questionJa": "袋をもらえますか？",
+          "answer": "Sure. A small bag is free.",
+          "answerJa": "もちろんです。小さい袋は無料です。"
+        },
+        {
+          "question": "Could I have a receipt?",
+          "questionJa": "レシートをもらえますか？",
+          "answer": "Of course. Here is your receipt.",
+          "answerJa": "もちろんです。こちらがレシートです。"
+        },
+        {
+          "question": "Is this tax-free?",
+          "questionJa": "これは免税できますか？",
+          "answer": "Yes, if you show your passport.",
+          "answerJa": "はい、パスポートを提示すれば免税できます。"
+        }
+      ]
+    },
+    {
+      "topic": "Transport and directions",
+      "mode": "anki",
+      "phrases": [
+        {
+          "question": "Where would you like to go?",
+          "questionJa": "どちらまで行きたいですか？",
+          "answer": "I’d like to go to the airport.",
+          "answerJa": "空港まで行きたいです。"
+        },
+        {
+          "question": "Could you show me the address?",
+          "questionJa": "住所を見せてもらえますか？",
+          "answer": "Please take me to this address.",
+          "answerJa": "この住所までお願いします。"
+        },
+        {
+          "question": "How long does it take from here?",
+          "questionJa": "ここからどれくらいかかりますか？",
+          "answer": "It takes about twenty minutes by train.",
+          "answerJa": "電車で約20分かかります。"
+        },
+        {
+          "question": "Where is the station?",
+          "questionJa": "駅はどこですか？",
+          "answer": "It’s two blocks down this street.",
+          "answerJa": "この通りを2ブロック先にあります。"
+        },
+        {
+          "question": "Can I walk there from here?",
+          "questionJa": "ここから歩けますか？",
+          "answer": "Yes, it’s about a ten-minute walk.",
+          "answerJa": "はい、歩いて約10分です。"
+        },
+        {
+          "question": "Could you call a taxi?",
+          "questionJa": "タクシーを呼んでもらえますか？",
+          "answer": "Sure. It should arrive in about five minutes.",
+          "answerJa": "もちろんです。約5分で到着するはずです。"
+        },
+        {
+          "question": "Does this train go to the airport?",
+          "questionJa": "この電車は空港に行きますか？",
+          "answer": "Yes, but you need to change trains once.",
+          "answerJa": "はい、ただし一度乗り換えが必要です。"
+        },
+        {
+          "question": "Which platform should I go to?",
+          "questionJa": "どのホームに行けばいいですか？",
+          "answer": "Please go to platform three.",
+          "answerJa": "3番ホームへ行ってください。"
+        },
+        {
+          "question": "Should I get off at the next station?",
+          "questionJa": "次の駅で降りればいいですか？",
+          "answer": "Yes, get off at the next station.",
+          "answerJa": "はい、次の駅で降りてください。"
+        },
+        {
+          "question": "Are you lost?",
+          "questionJa": "道に迷っていますか？",
+          "answer": "Yes, I’m lost. Could you help me?",
+          "answerJa": "はい、道に迷いました。助けてもらえますか？"
+        }
+      ]
+    },
+    {
+      "topic": "Trouble and health",
+      "mode": "anki",
+      "phrases": [
+        {
+          "question": "Could you help me?",
+          "questionJa": "助けてもらえますか？",
+          "answer": "Of course. What happened?",
+          "answerJa": "もちろんです。何がありましたか？"
+        },
+        {
+          "question": "What happened?",
+          "questionJa": "何がありましたか？",
+          "answer": "I lost my wallet.",
+          "answerJa": "財布をなくしました。"
+        },
+        {
+          "question": "What did you lose?",
+          "questionJa": "何をなくしましたか？",
+          "answer": "I lost my passport.",
+          "answerJa": "パスポートをなくしました。"
+        },
+        {
+          "question": "What’s wrong with your phone?",
+          "questionJa": "スマホはどうしましたか？",
+          "answer": "My phone isn’t working.",
+          "answerJa": "スマホが動きません。"
+        },
+        {
+          "question": "Are you feeling okay?",
+          "questionJa": "体調は大丈夫ですか？",
+          "answer": "I don’t feel well.",
+          "answerJa": "体調が悪いです。"
+        },
+        {
+          "question": "What are you looking for?",
+          "questionJa": "何を探していますか？",
+          "answer": "I’m looking for a pharmacy.",
+          "answerJa": "薬局を探しています。"
+        },
+        {
+          "question": "Where would you like to go?",
+          "questionJa": "どこへ行きたいですか？",
+          "answer": "I’d like to go to a hospital.",
+          "answerJa": "病院に行きたいです。"
+        },
+        {
+          "question": "What symptoms do you have?",
+          "questionJa": "どんな症状がありますか？",
+          "answer": "I have a headache.",
+          "answerJa": "頭が痛いです。"
+        },
+        {
+          "question": "Does your stomach hurt?",
+          "questionJa": "お腹が痛いですか？",
+          "answer": "Yes, I have a stomachache.",
+          "answerJa": "はい、お腹が痛いです。"
+        },
+        {
+          "question": "Is there anyone who speaks English?",
+          "questionJa": "英語を話せる人はいますか？",
+          "answer": "Yes, I can call someone who speaks English.",
+          "answerJa": "はい、英語を話せる人を呼べます。"
+        }
+      ]
+    },
+    {
+      "topic": "Pattern practice",
+      "mode": "anki",
+      "phrases": [
+        {
+          "question": "What would you like to do?",
+          "questionJa": "何をしたいですか？",
+          "answer": "I’d like to check in.",
+          "answerJa": "チェックインしたいです。"
+        },
+        {
+          "question": "How can I help with your reservation?",
+          "questionJa": "予約についてどのようにお手伝いできますか？",
+          "answer": "I’d like to change my reservation.",
+          "answerJa": "予約を変更したいです。"
+        },
+        {
+          "question": "Which ticket would you like?",
+          "questionJa": "どのチケットをご希望ですか？",
+          "answer": "I’d like to buy this ticket.",
+          "answerJa": "このチケットを買いたいです。"
+        },
+        {
+          "question": "Could you take a picture of me?",
+          "questionJa": "写真を撮ってもらえますか？",
+          "answer": "Sure. Where would you like to stand?",
+          "answerJa": "もちろんです。どこに立ちたいですか？"
+        },
+        {
+          "question": "Could you write it down?",
+          "questionJa": "ここに書いてもらえますか？",
+          "answer": "Sure. I’ll write it here.",
+          "answerJa": "もちろんです。ここに書きます。"
+        },
+        {
+          "question": "Do you have an English menu?",
+          "questionJa": "英語のメニューはありますか？",
+          "answer": "Yes, here is the English menu.",
+          "answerJa": "はい、こちらが英語のメニューです。"
+        },
+        {
+          "question": "Do you have any vegetarian options?",
+          "questionJa": "ベジタリアン向けの料理はありますか？",
+          "answer": "Yes, we have a few vegetarian dishes.",
+          "answerJa": "はい、いくつかベジタリアン向けの料理があります。"
+        },
+        {
+          "question": "What are you looking for?",
+          "questionJa": "何を探していますか？",
+          "answer": "I’m looking for an ATM.",
+          "answerJa": "ATMを探しています。"
+        },
+        {
+          "question": "Are you looking for anything in particular?",
+          "questionJa": "何か特定のものをお探しですか？",
+          "answer": "I’m looking for souvenirs.",
+          "answerJa": "お土産を探しています。"
+        },
+        {
+          "question": "Is there a restroom nearby?",
+          "questionJa": "この近くにトイレはありますか？",
+          "answer": "Yes, there is one next to the elevator.",
+          "answerJa": "はい、エレベーターの隣にあります。"
+        }
+      ]
+    },
+    {
+      "topic": "Small talk",
+      "mode": "anki",
+      "phrases": [
+        {
+          "question": "Where are you from?",
+          "questionJa": "どこ出身ですか？",
+          "answer": "I’m from Japan.",
+          "answerJa": "日本出身です。"
+        },
+        {
+          "question": "Where do you live?",
+          "questionJa": "どこに住んでいますか？",
+          "answer": "I live in Osaka.",
+          "answerJa": "大阪に住んでいます。"
+        },
+        {
+          "question": "What do you do?",
+          "questionJa": "仕事は何をしていますか？",
+          "answer": "I work as a data engineer.",
+          "answerJa": "データエンジニアとして働いています。"
+        },
+        {
+          "question": "What kind of work do you usually do?",
+          "questionJa": "普段はどのような仕事をしていますか？",
+          "answer": "I usually work with data pipelines and cloud services.",
+          "answerJa": "普段はデータ基盤やクラウドサービスを扱っています。"
+        },
+        {
+          "question": "What are your hobbies?",
+          "questionJa": "趣味は何ですか？",
+          "answer": "My hobbies are music and playing guitar.",
+          "answerJa": "趣味は音楽とギターです。"
+        },
+        {
+          "question": "What kind of music do you like?",
+          "questionJa": "どんな音楽が好きですか？",
+          "answer": "I especially like heavy music, such as modern metal.",
+          "answerJa": "特にモダンメタルのようなヘヴィな音楽が好きです。"
+        },
+        {
+          "question": "Why do you like traveling?",
+          "questionJa": "なぜ旅行が好きなのですか？",
+          "answer": "I like traveling because I enjoy seeing historical places and experiencing local culture.",
+          "answerJa": "歴史的な場所を見たり、現地の文化を体験したりするのが好きなので、旅行が好きです。"
+        },
+        {
+          "question": "What are you looking forward to on this trip?",
+          "questionJa": "今回の旅行で何を楽しみにしていますか？",
+          "answer": "I’m looking forward to trying local food and walking around the city.",
+          "answerJa": "現地の食べ物を試したり、街を歩いたりするのを楽しみにしています。"
+        },
+        {
+          "question": "Do you speak English?",
+          "questionJa": "英語を話せますか？",
+          "answer": "I don’t speak English perfectly, but I want to communicate as much as I can.",
+          "answerJa": "英語は完璧ではありませんが、できるだけコミュニケーションを取りたいです。"
+        },
+        {
+          "question": "Have you ever been here before?",
+          "questionJa": "以前ここに来たことはありますか？",
+          "answer": "No, this is my first time here.",
+          "answerJa": "いいえ、ここに来るのは初めてです。"
+        }
+      ]
+    }
+  ]
+}

--- a/apps/frontend/src/routes/AppPage.tsx
+++ b/apps/frontend/src/routes/AppPage.tsx
@@ -1,7 +1,5 @@
-import { LogOut } from "lucide-react";
+import AppHeader from "@/components/AppHeader";
 import PronunciationAssessment from "@/components/PronunciationAssessment";
-import { Button } from "@/components/ui/button";
-import { logout } from "@/lib/auth";
 
 type AppPageProps = {
   userName: string | null;
@@ -17,41 +15,7 @@ function AppPage({ userName }: AppPageProps) {
       </div>
 
       <section className="relative mx-auto w-full max-w-6xl space-y-4">
-        <header className="space-y-3 text-left">
-          <div className="flex items-center justify-start gap-5">
-            <img
-              src="/app_icon.png"
-              alt="re-say icon"
-              className="h-16 w-16 rounded-2xl shadow-md ring-1 ring-black/10"
-            />
-            <span className="text-balance text-4xl font-black leading-tight tracking-tight text-slate-900 dark:text-white">
-              re-say!
-            </span>
-          </div>
-
-          <div className="flex items-end justify-between gap-4">
-            <div className="flex flex-col items-start gap-1">
-              <p className="text-sm font-light text-slate-600 dark:text-slate-300">
-                英語発音練習アプリ
-              </p>
-              {userName && (
-                <p className="text-sm font-medium text-slate-600 dark:text-slate-300">
-                  Signed in as {userName}
-                </p>
-              )}
-            </div>
-
-            <Button
-              type="button"
-              variant="outline"
-              onClick={logout}
-              className="h-11 shrink-0 border-slate-300/80 bg-white/85 px-4 text-sm"
-            >
-              <LogOut className="size-4" />
-              Sign out
-            </Button>
-          </div>
-        </header>
+        <AppHeader userName={userName} subtitle="英語発音練習アプリ" />
         <PronunciationAssessment />
       </section>
     </main>

--- a/apps/frontend/src/routes/FlashCardsPage.tsx
+++ b/apps/frontend/src/routes/FlashCardsPage.tsx
@@ -1,0 +1,19 @@
+import AppHeader from "@/components/AppHeader";
+import FlashCards from "@/components/flash-cards/FlashCards";
+
+type FlashCardsPageProps = {
+  userName: string | null;
+};
+
+function FlashCardsPage({ userName }: FlashCardsPageProps) {
+  return (
+    <main className="relative min-h-screen overflow-hidden px-4 py-8 sm:px-6 lg:px-10">
+      <section className="relative mx-auto w-full max-w-5xl space-y-5">
+        <AppHeader userName={userName} subtitle="英会話フラッシュカード" />
+        <FlashCards />
+      </section>
+    </main>
+  );
+}
+
+export default FlashCardsPage;


### PR DESCRIPTION
## 概要
- `/flash_cards` ページを追加し、日常英会話のフラッシュカード学習機能を実装
- カードのクリック反転、Prev/Next移動、SpeakによるTTS読み上げに対応
- 複数トピックの選択、英語本文と日本語訳の補助表示に対応
- 暗記用コンテンツを既存の発音練習コンテンツとは別JSONで管理